### PR TITLE
Add warning level management

### DIFF
--- a/power_widget.lua
+++ b/power_widget.lua
@@ -102,7 +102,6 @@ function widget:update()
 				     mynotification = { notif = nil, remind = 0 }
 				  end
 			       })
-	     -- screen = s})
 	  end
        else
 	  -- Notification exists, update its text


### PR DESCRIPTION
Add data and code to manage a (configurable : warn_percentage, warn_bg, warn_fg and warn_timeout) warning level. 

The warn-level notification disappears automatically after warn_timeout seconds, or if the user clicks on it. It will not reappear before critical battery level.

The critical-level notification disappears if the user clicks on it, but will reappear at next battery level change (if still decreasing).

Notifications disappear if battery is charging.
